### PR TITLE
Split time variables into elapsed and limit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install Taplo
-        run: cargo install --locked taplo-cli
+        run: cargo install --force --locked taplo-cli
 
       - name: Format
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install Taplo
-        run: cargo install --force --locked taplo-cli
+        run: which taplo || cargo install --locked taplo-cli
 
       - name: Format
         run: |

--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ You can specify the duration using numeric literals followed by a suffix:
 * `function: String` - The name of the function
 * `elapsed: Duration` - The elapsed time
 * `elapsed_str: String` - The elapsed time using the limit unit specified (defaults to milliseconds)
-* `elapsed_ns: u64` - The elapsed time in nanoseconds
-* `elapsed_nanos: u64` - The elapsed time in nanoseconds
-* `elapsed_nanoseconds: u64` - The elapsed time in nanoseconds
-* `elapsed_ms: u64` - The elapsed time in milliseconds
-* `elapsed_millis: u64` - The elapsed time in milliseconds
-* `elapsed_milliseconds: u64` - The elapsed time in milliseconds
+* `elapsed_ns: u128` - The elapsed time in nanoseconds
+* `elapsed_nanos: u128` - The elapsed time in nanoseconds
+* `elapsed_nanoseconds: u128` - The elapsed time in nanoseconds
+* `elapsed_ms: u128` - The elapsed time in milliseconds
+* `elapsed_millis: u128` - The elapsed time in milliseconds
+* `elapsed_milliseconds: u128` - The elapsed time in milliseconds
 * `elapsed_s: u64` - The elapsed time in seconds
 * `elapsed_secs: u64` - The elapsed time in seconds
 * `elapsed_seconds: u64` - The elapsed time in seconds
@@ -95,12 +95,12 @@ You can specify the duration using numeric literals followed by a suffix:
 * `elapsed_days: u64` - The elapsed time in days
 * `limit: Duration` - The name of the module
 * `limit_str: String` - The limit time using the limit unit specified (defaults to milliseconds)
-* `limit_ns: u64` - The limit time in nanoseconds
-* `limit_nanos: u64` - The limit time in nanoseconds
-* `limit_nanoseconds: u64` - The limit time in nanoseconds
-* `limit_ms: u64` - The limit time in milliseconds
-* `limit_millis: u64` - The limit time in milliseconds
-* `limit_milliseconds: u64` - The limit time in milliseconds
+* `limit_ns: u128` - The limit time in nanoseconds
+* `limit_nanos: u128` - The limit time in nanoseconds
+* `limit_nanoseconds: u128` - The limit time in nanoseconds
+* `limit_ms: u128` - The limit time in milliseconds
+* `limit_millis: u128` - The limit time in milliseconds
+* `limit_milliseconds: u128` - The limit time in milliseconds
 * `limit_s: u64` - The limit time in seconds
 * `limit_secs: u64` - The limit time in seconds
 * `limit_seconds: u64` - The limit time in seconds

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,26 +7,50 @@ use proc_macro2::Span;
 use quote::{quote, ToTokens};
 use syn::{parse_macro_input, punctuated::Punctuated, spanned::Spanned, token::Semi, *};
 
-fn parse_time(expr: &Expr) -> Result<Duration> {
+enum TimeUnit {
+    Nanoseconds,
+    Milliseconds,
+    Seconds,
+    Minutes,
+    Hours,
+    Days,
+}
+
+impl TimeUnit {
+    fn to_duration(&self, amount: u64) -> Duration {
+        match self {
+            TimeUnit::Nanoseconds => Duration::from_nanos(amount),
+            TimeUnit::Milliseconds => Duration::from_millis(amount),
+            TimeUnit::Seconds => Duration::from_secs(amount),
+            TimeUnit::Minutes => Duration::from_secs(amount * 60),
+            TimeUnit::Hours => Duration::from_secs(amount * 60 * 60),
+            TimeUnit::Days => Duration::from_secs(amount * 60 * 60 * 24),
+        }
+    }
+}
+
+fn parse_time(expr: &Expr) -> Result<(u64, TimeUnit)> {
     match expr {
         Expr::Lit(expr_lit) => match &expr_lit.lit {
-            syn::Lit::Int(literal) => match literal.suffix() {
-                "ns" => Ok(Duration::from_nanos(literal.base10_parse::<u64>()?)),
-                "ms" => Ok(Duration::from_millis(literal.base10_parse::<u64>()?)),
-                "s" => Ok(Duration::from_secs(literal.base10_parse::<u64>()?)),
-                "m" => Ok(Duration::from_secs(literal.base10_parse::<u64>()? * 60)),
-                "h" => Ok(Duration::from_secs(
-                    literal.base10_parse::<u64>()? * 60 * 60,
-                )),
-                "d" => Ok(Duration::from_secs(
-                    literal.base10_parse::<u64>()? * 60 * 60 * 24,
-                )),
-                "" => Ok(Duration::from_millis(literal.base10_parse::<u64>()?)),
-                suffix => Err(syn::Error::new(
-                    expr.span(),
-                    format!("Unexpected a numeric literal suffix {}", suffix),
-                )),
-            },
+            syn::Lit::Int(literal) => {
+                let amount = literal.base10_parse::<u64>()?;
+                let unit = match literal.suffix() {
+                    "ns" => TimeUnit::Nanoseconds,
+                    "ms" => TimeUnit::Milliseconds,
+                    "s" => TimeUnit::Seconds,
+                    "m" => TimeUnit::Minutes,
+                    "h" => TimeUnit::Hours,
+                    "d" => TimeUnit::Days,
+                    "" => TimeUnit::Milliseconds,
+                    suffix => {
+                        return Err(syn::Error::new(
+                            expr.span(),
+                            format!("Unexpected a numeric literal suffix {}", suffix),
+                        ))
+                    }
+                };
+                Ok((amount, unit))
+            }
             _ => Err(syn::Error::new(expr.span(), "Expected a numeric literal")),
         },
         _ => Err(syn::Error::new(expr.span(), "Expected a numeric literal")),
@@ -42,14 +66,17 @@ pub fn slow_function_warning(args: TokenStream, input: TokenStream) -> TokenStre
     } else {
         Punctuated::default()
     };
+
     let Item::Fn(function) = syn::parse(input).unwrap() else {
         panic!("slow_function_warning can only be used on functions");
     };
-    let time = if let Some(time_expr) = args.get(0) {
+
+    let (time, unit) = if let Some(time_expr) = args.get(0) {
         parse_time(time_expr).unwrap()
     } else {
-        Duration::from_millis(1)
+        (1, TimeUnit::Milliseconds)
     };
+
     let stmt = if let Some(stmt) = args.get(1) {
         Stmt::Expr(stmt.clone(), Some(Semi::default()))
     } else {
@@ -61,11 +88,9 @@ pub fn slow_function_warning(args: TokenStream, input: TokenStream) -> TokenStre
         )
         .unwrap()
     };
-    slow_function_warning_common(time, stmt, function)
-}
 
-fn slow_function_warning_common(time: Duration, stmt: Stmt, function: ItemFn) -> TokenStream {
-    let nano_seconds = time.as_nanos();
+    let duration = unit.to_duration(time);
+    let nano_seconds = duration.as_nanos();
     let function_name_ident = function.sig.ident.clone();
     let function_name = Lit::Str(LitStr::new(
         &function_name_ident.to_string(),
@@ -125,6 +150,48 @@ fn slow_function_warning_common(time: Duration, stmt: Stmt, function: ItemFn) ->
         .unwrap()
     };
 
+    let elapsed_str = match unit {
+        TimeUnit::Nanoseconds => quote! {
+            format!("{}ns", elapsed.as_nanos())
+        },
+        TimeUnit::Milliseconds => quote! {
+            format!("{}ms", elapsed.as_millis())
+        },
+        TimeUnit::Seconds => quote! {
+            format!("{}s", elapsed.as_secs())
+        },
+        TimeUnit::Minutes => quote! {
+            format!("{}m", elapsed.as_secs() / 60)
+        },
+        TimeUnit::Hours => quote! {
+            format!("{}h", elapsed.as_secs() / 60 / 60)
+        },
+        TimeUnit::Days => quote! {
+            format!("{}d", elapsed.as_secs() / 60 / 60 / 24)
+        },
+    };
+
+    let limit_str = match unit {
+        TimeUnit::Nanoseconds => quote! {
+            format!("{}ns", limit.as_nanos())
+        },
+        TimeUnit::Milliseconds => quote! {
+            format!("{}ms", limit.as_millis())
+        },
+        TimeUnit::Seconds => quote! {
+            format!("{}s", limit.as_secs())
+        },
+        TimeUnit::Minutes => quote! {
+            format!("{}m", limit.as_secs() / 60)
+        },
+        TimeUnit::Hours => quote! {
+            format!("{}h", limit.as_secs() / 60 / 60)
+        },
+        TimeUnit::Days => quote! {
+            format!("{}d", limit.as_secs() / 60 / 60 / 24)
+        },
+    };
+
     result.block = syn::parse(
         quote! {{
             #closure_decleration
@@ -136,13 +203,45 @@ fn slow_function_warning_common(time: Duration, stmt: Stmt, function: ItemFn) ->
             if start.elapsed().as_nanos() > #nano_seconds {
                 let module = module_path!();
                 let function = #function_name;
+
                 let elapsed = start.elapsed();
-                let ns = elapsed.as_nanos();
-                let nanos = ns;
-                let ms = elapsed.as_millis();
-                let millis = ms;
-                let s = elapsed.as_secs();
-                let secs = s;
+                let elapsed_str = #elapsed_str;
+                let elapsed_ns = elapsed.as_nanos();
+                let elapsed_nanos = elapsed_ns;
+                let elapsed_nanoseconds = elapsed_ns;
+                let elapsed_ms = elapsed.as_millis();
+                let elapsed_millis = elapsed_ms;
+                let elapsed_milliseconds = elapsed_ms;
+                let elapsed_s = elapsed.as_secs();
+                let elapsed_secs = elapsed_s;
+                let elapsed_seconds = elapsed_s;
+                let elapsed_m = elapsed.as_secs() / 60;
+                let elapsed_min = elapsed_m;
+                let elapsed_minutes = elapsed_m;
+                let elapsed_h = elapsed.as_secs() / 60 / 60;
+                let elapsed_hours = elapsed_h;
+                let elapsed_d = elapsed.as_secs() / 60 / 60 / 24;
+                let elapsed_days = elapsed_d;
+
+                let limit = Duration::from_nanos(#nano_seconds as u64);
+                let limit_str = #limit_str;
+                let limit_ns = limit.as_nanos();
+                let limit_nanos = limit_ns;
+                let limit_nanoseconds = limit_ns;
+                let limit_ms = limit.as_millis();
+                let limit_millis = limit_ms;
+                let limit_milliseconds = limit_ms;
+                let limit_s = limit.as_secs();
+                let limit_secs = limit_s;
+                let limit_seconds = limit_s;
+                let limit_m = limit.as_secs() / 60;
+                let limit_min = limit_m;
+                let limit_minutes = limit_m;
+                let limit_h = limit.as_secs() / 60 / 60;
+                let limit_hours = limit_h;
+                let limit_d = limit.as_secs() / 60 / 60 / 24;
+                let limit_days = limit_d;
+
                 #stmt
             }
             result

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ use syn::{parse_macro_input, punctuated::Punctuated, spanned::Spanned, token::Se
 
 enum TimeUnit {
     Nanoseconds,
+    Microseconds,
     Milliseconds,
     Seconds,
     Minutes,
@@ -20,6 +21,7 @@ impl TimeUnit {
     fn to_duration(&self, amount: u64) -> Duration {
         match self {
             TimeUnit::Nanoseconds => Duration::from_nanos(amount),
+            TimeUnit::Microseconds => Duration::from_micros(amount),
             TimeUnit::Milliseconds => Duration::from_millis(amount),
             TimeUnit::Seconds => Duration::from_secs(amount),
             TimeUnit::Minutes => Duration::from_secs(amount * 60),
@@ -36,6 +38,7 @@ fn parse_time(expr: &Expr) -> Result<(u64, TimeUnit)> {
                 let amount = literal.base10_parse::<u64>()?;
                 let unit = match literal.suffix() {
                     "ns" => TimeUnit::Nanoseconds,
+                    "us" | "μs" => TimeUnit::Microseconds,
                     "ms" => TimeUnit::Milliseconds,
                     "s" => TimeUnit::Seconds,
                     "m" => TimeUnit::Minutes,
@@ -154,6 +157,9 @@ pub fn slow_function_warning(args: TokenStream, input: TokenStream) -> TokenStre
         TimeUnit::Nanoseconds => quote! {
             format!("{}ns", elapsed.as_nanos())
         },
+        TimeUnit::Microseconds => quote! {
+            format!("{}μs", elapsed.as_micros())
+        },
         TimeUnit::Milliseconds => quote! {
             format!("{}ms", elapsed.as_millis())
         },
@@ -174,6 +180,9 @@ pub fn slow_function_warning(args: TokenStream, input: TokenStream) -> TokenStre
     let limit_str = match unit {
         TimeUnit::Nanoseconds => quote! {
             format!("{}ns", limit.as_nanos())
+        },
+        TimeUnit::Microseconds => quote! {
+            format!("{}μs", limit.as_micros())
         },
         TimeUnit::Milliseconds => quote! {
             format!("{}ms", limit.as_millis())
@@ -209,6 +218,9 @@ pub fn slow_function_warning(args: TokenStream, input: TokenStream) -> TokenStre
                 let elapsed_ns = elapsed.as_nanos();
                 let elapsed_nanos = elapsed_ns;
                 let elapsed_nanoseconds = elapsed_ns;
+                let elapsed_us = elapsed.as_micros();
+                let elapsed_micros = elapsed_us;
+                let elapsed_microseconds = elapsed_us;
                 let elapsed_ms = elapsed.as_millis();
                 let elapsed_millis = elapsed_ms;
                 let elapsed_milliseconds = elapsed_ms;
@@ -228,6 +240,9 @@ pub fn slow_function_warning(args: TokenStream, input: TokenStream) -> TokenStre
                 let limit_ns = limit.as_nanos();
                 let limit_nanos = limit_ns;
                 let limit_nanoseconds = limit_ns;
+                let limit_us = limit.as_micros();
+                let limit_micros = limit_us;
+                let limit_microseconds = limit_us;
                 let limit_ms = limit.as_millis();
                 let limit_millis = limit_ms;
                 let limit_milliseconds = limit_ms;

--- a/tests/slow_function_warning.rs
+++ b/tests/slow_function_warning.rs
@@ -24,13 +24,13 @@ fn default_warning_compiles() {
 
 #[test]
 fn warn() {
-    #[slow_function_warning(10ms, {*warned = true;})]
+    #[slow_function_warning(1ms, {*warned = true;})]
     pub fn sleep(millis: u64, warned: &mut bool) {
         thread::sleep(Duration::from_millis(millis));
     }
 
     let mut warned = false;
-    sleep(100, &mut warned);
+    sleep(2, &mut warned);
 
     assert!(warned);
 }
@@ -50,7 +50,7 @@ fn no_warn() {
 
 #[test]
 fn warn_using_params() {
-    #[slow_function_warning(10ms, {
+    #[slow_function_warning(1ms, {
         println!("{module}::{function} {param}");
         *warned = true;
     })]
@@ -59,7 +59,7 @@ fn warn_using_params() {
     }
 
     let mut warned = false;
-    sleep(10, "trace id", &mut warned);
+    sleep(2, "trace id", &mut warned);
 
     assert!(warned);
 }
@@ -87,7 +87,7 @@ fn warn_impl() {
     }
 
     impl MyStruct {
-        #[slow_function_warning(10ms, {
+        #[slow_function_warning(1ms, {
             println!("{module}::{function} {param}");
             self.warned = true;
         })]
@@ -97,7 +97,7 @@ fn warn_impl() {
     }
 
     let mut my_struct = MyStruct { warned: false };
-    my_struct.sleep(10, "trace id");
+    my_struct.sleep(2, "trace id");
 
     assert!(my_struct.warned);
 }
@@ -126,7 +126,7 @@ fn no_warn_impl() {
 
 #[tokio::test]
 async fn warn_async() {
-    #[slow_function_warning(10ms, {
+    #[slow_function_warning(1ms, {
         println!("{module}::{function} {param}");
         *warned = true;
     })]
@@ -135,7 +135,7 @@ async fn warn_async() {
     }
 
     let mut warned = false;
-    sleep(10, "trace id", &mut warned).await;
+    sleep(2, "trace id", &mut warned).await;
 
     assert!(warned);
 }
@@ -154,17 +154,4 @@ async fn no_warn_async() {
     sleep(1, "trace id", &mut warned).await;
 
     assert!(!warned);
-}
-
-#[test]
-fn limit() {
-    #[slow_function_warning(10ms, {*duration = limit.clone();})]
-    pub fn sleep(millis: u64, duration: &mut Duration) {
-        thread::sleep(Duration::from_millis(millis));
-    }
-
-    let mut duration = Duration::default();
-    sleep(100, &mut duration);
-
-    assert_eq!(duration.as_millis(), 10);
 }

--- a/tests/slow_function_warning.rs
+++ b/tests/slow_function_warning.rs
@@ -23,7 +23,6 @@ fn default_warning_compiles() {
 
 #[test]
 fn warn() {
-    #[allow(unused_variables)]
     #[slow_function_warning(10ms, {*warned = true;})]
     pub fn sleep(millis: u64, warned: &mut bool) {
         thread::sleep(Duration::from_millis(millis));
@@ -37,7 +36,6 @@ fn warn() {
 
 #[test]
 fn no_warn() {
-    #[allow(unused_variables)]
     #[slow_function_warning(10ms, {*warned = true;})]
     pub fn sleep(millis: u64, warned: &mut bool) {
         thread::sleep(Duration::from_millis(millis));
@@ -51,7 +49,6 @@ fn no_warn() {
 
 #[test]
 fn warn_using_params() {
-    #[allow(unused_variables)]
     #[slow_function_warning(10ms, {
         println!("{module}::{function} {param}");
         *warned = true;
@@ -68,7 +65,6 @@ fn warn_using_params() {
 
 #[test]
 fn no_warn_using_params() {
-    #[allow(unused_variables)]
     #[slow_function_warning(10ms, {
         println!("{module}::{function} {param}");
         *warned = true;
@@ -90,7 +86,6 @@ fn warn_impl() {
     }
 
     impl MyStruct {
-        #[allow(unused_variables)]
         #[slow_function_warning(10ms, {
             println!("{module}::{function} {param}");
             self.warned = true;
@@ -113,7 +108,6 @@ fn no_warn_impl() {
     }
 
     impl MyStruct {
-        #[allow(unused_variables)]
         #[slow_function_warning(10ms, {
             println!("{module}::{function} {param}");
             self.warned = true;
@@ -131,7 +125,6 @@ fn no_warn_impl() {
 
 #[tokio::test]
 async fn warn_async() {
-    #[allow(unused_variables)]
     #[slow_function_warning(10ms, {
         println!("{module}::{function} {param}");
         *warned = true;
@@ -148,7 +141,6 @@ async fn warn_async() {
 
 #[tokio::test]
 async fn no_warn_async() {
-    #[allow(unused_variables)]
     #[slow_function_warning(50ms, {
         println!("{module}::{function} {param}");
         *warned = true;
@@ -161,4 +153,17 @@ async fn no_warn_async() {
     sleep(1, "trace id", &mut warned).await;
 
     assert!(!warned);
+}
+
+#[test]
+fn limit() {
+    #[slow_function_warning(10ms, {*duration = limit.clone();})]
+    pub fn sleep(millis: u64, duration: &mut Duration) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut duration = Duration::default();
+    sleep(100, &mut duration);
+
+    assert_eq!(duration.as_millis(), 10);
 }

--- a/tests/variables.rs
+++ b/tests/variables.rs
@@ -30,7 +30,7 @@ fn function() {
 
 #[test]
 fn elapsed() {
-    #[slow_function_warning(1ms, {*duration = elapsed.clone();})]
+    #[slow_function_warning(1ms, {*duration = elapsed;})]
     pub fn sleep(millis: u64, duration: &mut Duration) {
         thread::sleep(Duration::from_millis(millis));
     }
@@ -303,7 +303,7 @@ fn elapsed_days() {
 
 #[test]
 fn limit() {
-    #[slow_function_warning(1ms, {*duration = limit.clone();})]
+    #[slow_function_warning(1ms, {*duration = limit;})]
     pub fn sleep(millis: u64, duration: &mut Duration) {
         thread::sleep(Duration::from_millis(millis));
     }

--- a/tests/variables.rs
+++ b/tests/variables.rs
@@ -1,0 +1,575 @@
+use std::{thread, time::Duration};
+
+use slow_function_warning::*;
+
+#[test]
+fn module() {
+    #[slow_function_warning(1ms, {*value = module.to_string();})]
+    pub fn sleep(millis: u64, value: &mut String) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = "".to_string();
+    sleep(2, &mut value);
+
+    assert_eq!(value, "variables");
+}
+
+#[test]
+fn function() {
+    #[slow_function_warning(1ms, {*value = function.to_string();})]
+    pub fn sleep(millis: u64, value: &mut String) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = "".to_string();
+    sleep(2, &mut value);
+
+    assert_eq!(value, "sleep");
+}
+
+#[test]
+fn elapsed() {
+    #[slow_function_warning(1ms, {*duration = elapsed.clone();})]
+    pub fn sleep(millis: u64, duration: &mut Duration) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut duration = Duration::default();
+    sleep(2, &mut duration);
+
+    assert_eq!(duration.as_millis(), 2);
+}
+
+#[test]
+fn elapsed_str() {
+    #[slow_function_warning(1ms, {*value = elapsed_str.clone();})]
+    pub fn sleep(millis: u64, value: &mut String) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = "".to_string();
+    sleep(2, &mut value);
+
+    assert_eq!(value, "2ms");
+}
+
+#[test]
+fn elapsed_ns() {
+    #[slow_function_warning(1ms, {*value = elapsed_ns;})]
+    pub fn sleep(millis: u64, value: &mut u128) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u128::default();
+    sleep(2, &mut value);
+
+    assert!(value > 2000000);
+}
+
+#[test]
+fn elapsed_nanos() {
+    #[slow_function_warning(1ms, {*value = elapsed_nanos;})]
+    pub fn sleep(millis: u64, value: &mut u128) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u128::default();
+    sleep(2, &mut value);
+
+    assert!(value > 2000000);
+}
+
+#[test]
+fn elapsed_nanoseconds() {
+    #[slow_function_warning(1ms, {*value = elapsed_nanoseconds;})]
+    pub fn sleep(millis: u64, value: &mut u128) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u128::default();
+    sleep(2, &mut value);
+
+    assert!(value > 2000000);
+}
+
+#[test]
+fn elapsed_us() {
+    #[slow_function_warning(1ms, {*value = elapsed_us;})]
+    pub fn sleep(millis: u64, value: &mut u128) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u128::default();
+    sleep(2, &mut value);
+
+    assert!(value > 2000);
+}
+
+#[test]
+fn elapsed_micros() {
+    #[slow_function_warning(1ms, {*value = elapsed_micros;})]
+    pub fn sleep(millis: u64, value: &mut u128) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u128::default();
+    sleep(2, &mut value);
+
+    assert!(value > 2000);
+}
+
+#[test]
+fn elapsed_microseconds() {
+    #[slow_function_warning(1ms, {*value = elapsed_microseconds;})]
+    pub fn sleep(millis: u64, value: &mut u128) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u128::default();
+    sleep(2, &mut value);
+
+    assert!(value > 2000);
+}
+
+#[test]
+fn elapsed_ms() {
+    #[slow_function_warning(1ms, {*value = elapsed_ms;})]
+    pub fn sleep(millis: u64, value: &mut u128) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u128::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 2);
+}
+
+#[test]
+fn elapsed_millis() {
+    #[slow_function_warning(1ms, {*value = elapsed_millis;})]
+    pub fn sleep(millis: u64, value: &mut u128) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u128::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 2);
+}
+
+#[test]
+fn elapsed_milliseconds() {
+    #[slow_function_warning(1ms, {*value = elapsed_milliseconds;})]
+    pub fn sleep(millis: u64, value: &mut u128) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u128::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 2);
+}
+
+#[test]
+fn elapsed_s() {
+    #[slow_function_warning(1ms, {*value = elapsed_s;})]
+    pub fn sleep(millis: u64, value: &mut u64) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u64::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 0);
+}
+
+#[test]
+fn elapsed_secs() {
+    #[slow_function_warning(1ms, {*value = elapsed_secs;})]
+    pub fn sleep(millis: u64, value: &mut u64) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u64::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 0);
+}
+
+#[test]
+fn elapsed_seconds() {
+    #[slow_function_warning(1ms, {*value = elapsed_seconds;})]
+    pub fn sleep(millis: u64, value: &mut u64) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u64::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 0);
+}
+
+#[test]
+fn elapsed_m() {
+    #[slow_function_warning(1ms, {*value = elapsed_m;})]
+    pub fn sleep(millis: u64, value: &mut u64) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u64::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 0);
+}
+
+#[test]
+fn elapsed_min() {
+    #[slow_function_warning(1ms, {*value = elapsed_min;})]
+    pub fn sleep(millis: u64, value: &mut u64) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u64::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 0);
+}
+
+#[test]
+fn elapsed_minutes() {
+    #[slow_function_warning(1ms, {*value = elapsed_minutes;})]
+    pub fn sleep(millis: u64, value: &mut u64) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u64::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 0);
+}
+
+#[test]
+fn elapsed_h() {
+    #[slow_function_warning(1ms, {*value = elapsed_h;})]
+    pub fn sleep(millis: u64, value: &mut u64) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u64::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 0);
+}
+
+#[test]
+fn elapsed_hours() {
+    #[slow_function_warning(1ms, {*value = elapsed_hours;})]
+    pub fn sleep(millis: u64, value: &mut u64) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u64::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 0);
+}
+
+#[test]
+fn elapsed_d() {
+    #[slow_function_warning(1ms, {*value = elapsed_d;})]
+    pub fn sleep(millis: u64, value: &mut u64) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u64::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 0);
+}
+
+#[test]
+fn elapsed_days() {
+    #[slow_function_warning(1ms, {*value = elapsed_days;})]
+    pub fn sleep(millis: u64, value: &mut u64) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u64::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 0);
+}
+
+#[test]
+fn limit() {
+    #[slow_function_warning(1ms, {*duration = limit.clone();})]
+    pub fn sleep(millis: u64, duration: &mut Duration) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut duration = Duration::default();
+    sleep(2, &mut duration);
+
+    assert_eq!(duration.as_millis(), 1);
+}
+
+#[test]
+fn limit_str() {
+    #[slow_function_warning(1ms, {*value = limit_str.clone();})]
+    pub fn sleep(millis: u64, value: &mut String) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = "".to_string();
+    sleep(2, &mut value);
+
+    assert_eq!(value, "1ms");
+}
+
+#[test]
+fn limit_ns() {
+    #[slow_function_warning(1ms, {*value = limit_ns;})]
+    pub fn sleep(millis: u64, value: &mut u128) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u128::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 1000000);
+}
+
+#[test]
+fn limit_nanos() {
+    #[slow_function_warning(1ms, {*value = limit_nanos;})]
+    pub fn sleep(millis: u64, value: &mut u128) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u128::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 1000000);
+}
+
+#[test]
+fn limit_nanoseconds() {
+    #[slow_function_warning(1ms, {*value = limit_nanoseconds;})]
+    pub fn sleep(millis: u64, value: &mut u128) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u128::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 1000000);
+}
+
+#[test]
+fn limit_us() {
+    #[slow_function_warning(1ms, {*value = limit_us;})]
+    pub fn sleep(millis: u64, value: &mut u128) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u128::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 1000);
+}
+
+#[test]
+fn limit_micros() {
+    #[slow_function_warning(1ms, {*value = limit_micros;})]
+    pub fn sleep(millis: u64, value: &mut u128) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u128::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 1000);
+}
+
+#[test]
+fn limit_microseconds() {
+    #[slow_function_warning(1ms, {*value = limit_microseconds;})]
+    pub fn sleep(millis: u64, value: &mut u128) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u128::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 1000);
+}
+
+#[test]
+fn limit_ms() {
+    #[slow_function_warning(1ms, {*value = limit_ms;})]
+    pub fn sleep(millis: u64, value: &mut u128) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u128::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 1);
+}
+
+#[test]
+fn limit_millis() {
+    #[slow_function_warning(1ms, {*value = limit_millis;})]
+    pub fn sleep(millis: u64, value: &mut u128) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u128::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 1);
+}
+
+#[test]
+fn limit_milliseconds() {
+    #[slow_function_warning(1ms, {*value = limit_milliseconds;})]
+    pub fn sleep(millis: u64, value: &mut u128) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u128::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 1);
+}
+
+#[test]
+fn limit_s() {
+    #[slow_function_warning(1ms, {*value = limit_s;})]
+    pub fn sleep(millis: u64, value: &mut u64) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u64::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 0);
+}
+
+#[test]
+fn limit_secs() {
+    #[slow_function_warning(1ms, {*value = limit_secs;})]
+    pub fn sleep(millis: u64, value: &mut u64) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u64::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 0);
+}
+
+#[test]
+fn limit_seconds() {
+    #[slow_function_warning(1ms, {*value = limit_seconds;})]
+    pub fn sleep(millis: u64, value: &mut u64) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u64::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 0);
+}
+
+#[test]
+fn limit_m() {
+    #[slow_function_warning(1ms, {*value = limit_m;})]
+    pub fn sleep(millis: u64, value: &mut u64) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u64::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 0);
+}
+
+#[test]
+fn limit_min() {
+    #[slow_function_warning(1ms, {*value = limit_min;})]
+    pub fn sleep(millis: u64, value: &mut u64) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u64::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 0);
+}
+
+#[test]
+fn limit_minutes() {
+    #[slow_function_warning(1ms, {*value = limit_minutes;})]
+    pub fn sleep(millis: u64, value: &mut u64) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u64::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 0);
+}
+
+#[test]
+fn limit_h() {
+    #[slow_function_warning(1ms, {*value = limit_h;})]
+    pub fn sleep(millis: u64, value: &mut u64) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u64::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 0);
+}
+
+#[test]
+fn limit_hours() {
+    #[slow_function_warning(1ms, {*value = limit_hours;})]
+    pub fn sleep(millis: u64, value: &mut u64) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u64::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 0);
+}
+
+#[test]
+fn limit_d() {
+    #[slow_function_warning(1ms, {*value = limit_d;})]
+    pub fn sleep(millis: u64, value: &mut u64) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u64::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 0);
+}
+
+#[test]
+fn limit_days() {
+    #[slow_function_warning(1ms, {*value = limit_days;})]
+    pub fn sleep(millis: u64, value: &mut u64) {
+        thread::sleep(Duration::from_millis(millis));
+    }
+
+    let mut value = u64::default();
+    sleep(2, &mut value);
+
+    assert_eq!(value, 0);
+}


### PR DESCRIPTION
https://github.com/ironpeak/slow_function_warning/issues/5

Allow users to use the user set limit in the log message.